### PR TITLE
Feat/infra mappers

### DIFF
--- a/src/infra/database/mapper/prisma-balance-mapper.ts
+++ b/src/infra/database/mapper/prisma-balance-mapper.ts
@@ -1,0 +1,29 @@
+import type { Prisma, Balance as PrismaBalance } from '@prisma/client';
+import { Balance } from '../../../domain/budget-manager/enterprise/entities/balance';
+import { UniqueEntityId } from '../../../core/entitites/unique-entity-id';
+
+// biome-ignore lint/complexity/noStaticOnlyClass:
+export class PrismaBalanceMapper {
+  static toDomain(prismaBalance: PrismaBalance): Balance {
+    return Balance.create(
+      {
+        userId: new UniqueEntityId(prismaBalance.user_id),
+        amount: prismaBalance.amount,
+        createdAt: prismaBalance.createdAt,
+      },
+      prismaBalance.id,
+    );
+  }
+
+  static toPrisma(balance: Balance): Prisma.BalanceCreateInput {
+    return {
+      amount: balance.amount,
+      createdAt: balance.createdAt,
+      user: {
+        connect: {
+          id: balance.userId.value,
+        },
+      },
+    };
+  }
+}

--- a/src/infra/database/mapper/prisma-category-mapper.ts
+++ b/src/infra/database/mapper/prisma-category-mapper.ts
@@ -1,0 +1,24 @@
+import type { Prisma, Category as PrismaCategory } from '@prisma/client';
+import { Category } from '../../../domain/budget-manager/enterprise/entities/category';
+
+// biome-ignore lint/complexity/noStaticOnlyClass:
+export class PrismaCategoryMapper {
+  static toDomain(prismaCategory: PrismaCategory): Category {
+    return Category.create(
+      {
+        name: prismaCategory.name,
+        type: prismaCategory.type,
+        createdAt: prismaCategory.createdAt,
+      },
+      prismaCategory.id,
+    );
+  }
+
+  static toPrisma(category: Category): Prisma.CategoryCreateInput {
+    return {
+      name: category.name,
+      type: category.type,
+      createdAt: category.createdAt,
+    };
+  }
+}

--- a/src/infra/database/mapper/prisma-financial-goals-mapper.ts
+++ b/src/infra/database/mapper/prisma-financial-goals-mapper.ts
@@ -1,0 +1,37 @@
+import type {
+  Prisma,
+  FinancialGoals as PrismaFinancialGoals,
+} from '@prisma/client';
+import { FinancialGoals } from '../../../domain/budget-manager/enterprise/entities/financial-goals';
+
+// biome-ignore lint/complexity/noStaticOnlyClass:
+export class PrismaFinancialGoalsMapper {
+  static toDomain(prismaFinancialGoals: PrismaFinancialGoals): FinancialGoals {
+    return FinancialGoals.create(
+      {
+        goalValue: prismaFinancialGoals.goalValue,
+        goalDate: prismaFinancialGoals.goalDate,
+        description: prismaFinancialGoals.description,
+        createdAt: prismaFinancialGoals.createdAt,
+        userId: prismaFinancialGoals.user_id,
+      },
+      prismaFinancialGoals.id,
+    );
+  }
+
+  static toPrisma(
+    financialgoals: FinancialGoals,
+  ): Prisma.FinancialGoalsCreateInput {
+    return {
+      description: financialgoals.description,
+      goalDate: financialgoals.goalDate,
+      goalValue: financialgoals.goalValue,
+      createdAt: financialgoals.createdAt,
+      user: {
+        connect: {
+          id: financialgoals.userId,
+        },
+      },
+    };
+  }
+}

--- a/src/infra/database/mapper/prisma-transaction-mapper.ts
+++ b/src/infra/database/mapper/prisma-transaction-mapper.ts
@@ -1,0 +1,34 @@
+import type { Prisma, Transactions as PrismaTransaction } from '@prisma/client';
+import { Transaction } from '../../../domain/budget-manager/enterprise/entities/transaction';
+import { UniqueEntityId } from '../../../core/entitites/unique-entity-id';
+
+// biome-ignore lint/complexity/noStaticOnlyClass:
+export class PrismaTransactionMapper {
+  static toDomain(prismaTransactionMapper: PrismaTransaction): Transaction {
+    return Transaction.create(
+      {
+        amount: prismaTransactionMapper.amount,
+        balanceId: new UniqueEntityId(prismaTransactionMapper.balanceId),
+        categoryId: new UniqueEntityId(prismaTransactionMapper.categoryId),
+        date: prismaTransactionMapper.date,
+        description: prismaTransactionMapper.description,
+        type: prismaTransactionMapper.type,
+        userId: new UniqueEntityId(prismaTransactionMapper.userId),
+      },
+      prismaTransactionMapper.id,
+    );
+  }
+
+  static toPrisma(transaction: Transaction): Prisma.TransactionsCreateInput {
+    return {
+      id: transaction.id.toString(),
+      amount: transaction.amount,
+      description: transaction.description,
+      date: transaction.date,
+      type: transaction.type,
+      balance: { connect: { id: transaction.balanceId.toString() } },
+      category: { connect: { id: transaction.categoryId.toString() } },
+      user: { connect: { id: transaction.userId.toString() } },
+    };
+  }
+}

--- a/src/infra/database/mapper/prisma-user-mapper.ts
+++ b/src/infra/database/mapper/prisma-user-mapper.ts
@@ -1,0 +1,24 @@
+import { User } from '../../../domain/budget-manager/enterprise/entities/user';
+import type { Prisma, User as PrismaUser } from '@prisma/client';
+
+// biome-ignore lint/complexity/noStaticOnlyClass: 
+export class PrismaUserMapper {
+  static toDomain(prismaUser: PrismaUser): User {
+    return new User(
+      {
+        name: prismaUser.name,
+        email: prismaUser.email,
+        passwordHash: prismaUser.password_hash,
+      },
+      prismaUser.id, 
+    );
+  }
+
+  static toPrisma(user: User): Prisma.UserCreateInput {
+    return {
+      name: user.name,
+      email: user.email,
+      password_hash: user.passwordHash,
+    };
+  }
+}


### PR DESCRIPTION
This pull request introduces several new mapper classes to convert between Prisma models and domain entities for various components in the budget manager system. The most important changes include the addition of mappers for balances, categories, financial goals, transactions, and users.

New Mapper Classes:

* [`src/infra/database/mapper/prisma-balance-mapper.ts`](diffhunk://#diff-a2b2ba0eba0a89e51586c395e2406d97c5f929f5e066b60055113df8f3d0dec6R1-R29): Added `PrismaBalanceMapper` to convert between `PrismaBalance` and `Balance` domain entity.
* [`src/infra/database/mapper/prisma-category-mapper.ts`](diffhunk://#diff-90f01e2eacd39c75309e8c37f9ba3a3974cb722b3cb9d39105ed58fb12809bdfR1-R24): Added `PrismaCategoryMapper` to convert between `PrismaCategory` and `Category` domain entity.
* [`src/infra/database/mapper/prisma-financial-goals-mapper.ts`](diffhunk://#diff-336f8a606774dd165e99087e1c53a39e6bc3a8844f046fbbe684b03647491ec9R1-R37): Added `PrismaFinancialGoalsMapper` to convert between `PrismaFinancialGoals` and `FinancialGoals` domain entity.
* [`src/infra/database/mapper/prisma-transaction-mapper.ts`](diffhunk://#diff-14ec3c611e8abe2e11f92008bcb93e306bb67527620560d5f727cb6a7737684bR1-R34): Added `PrismaTransactionMapper` to convert between `PrismaTransaction` and `Transaction` domain entity.
* [`src/infra/database/mapper/prisma-user-mapper.ts`](diffhunk://#diff-6f68ef50bbcb3cc1b32490490c286b970b820d51e50462047d0a1257abf8effeR1-R24): Added `PrismaUserMapper` to convert between `PrismaUser` and `User` domain entity.