### PR TITLE
feat: create a ci to run tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run unit tests
+        run: pnpm test
+
+      - name: Run E2E tests
+        run: pnpm test:e2e


### PR DESCRIPTION
This pull request introduces a new Continuous Integration (CI) workflow using GitHub Actions. The changes include setting up the workflow to run on pushes and pull requests to the main branch, and configuring the necessary steps to install dependencies and run tests.

New CI workflow setup:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR1-R35): Added a new CI workflow configuration that triggers on pushes and pull requests to the main branch, sets up the Node.js environment, installs dependencies using `pnpm`, and runs both unit and end-to-end tests.